### PR TITLE
Add Chicory Runtime to implementation configuration instead of api

### DIFF
--- a/plugin/src/main/kotlin/AndroidPluginIntegration.kt
+++ b/plugin/src/main/kotlin/AndroidPluginIntegration.kt
@@ -92,7 +92,7 @@ internal fun Project.setupAndroidPluginIntegration() {
         variant.compileConfiguration.extendsFrom(aotMachineJarConfiguration)
     }
 
-    project.dependencies.add("api", Deps.CHICORY_RUNTIME)
+    project.dependencies.add("implementation", Deps.CHICORY_RUNTIME)
 }
 
 internal class ExtensionMerger(

--- a/plugin/src/main/kotlin/KotlinMultiplatformPluginIntegration.kt
+++ b/plugin/src/main/kotlin/KotlinMultiplatformPluginIntegration.kt
@@ -56,7 +56,7 @@ internal fun Project.setupKotlinMultiplatformPluginIntegration() {
                         aotModuleClasses,
                     )
                     dependencies {
-                        api(Deps.CHICORY_RUNTIME)
+                        implementation(Deps.CHICORY_RUNTIME)
                         compileOnly(files(aotModuleClasses, outputClasses))
                     }
                 }


### PR DESCRIPTION
Assuming it will only be used from the Gradle project where the AOT module was generated.