### PR TITLE
Update Chicory to 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,16 +124,12 @@ androidComponents {
 If you're using R8 or ProGuard in your project, you may need to add the following rules:
 
 ```
--dontwarn com.dylibso.chicory.experimental.hostmodule.annotations.Buffer
--dontwarn com.dylibso.chicory.experimental.hostmodule.annotations.HostModule
--dontwarn com.dylibso.chicory.experimental.hostmodule.annotations.WasmExport
 -dontwarn com.google.errorprone.annotations.FormatMethod
 -dontwarn java.lang.System$Logger$Level
 -dontwarn java.lang.System$Logger
 
--keepclasseswithmembers,allowoptimization public final class **Module {
-    public static com.dylibso.chicory.wasm.WasmModule load();
-}
+-if public final class ** { public static com.dylibso.chicory.wasm.WasmModule load(); }
+-keepnames class <1>
 ```
 
 The `**Module.load()` method in generated modules relies on `XXXModule.class.getResourceAsStream()` 

--- a/functional-test-utils/src/main/kotlin/apk/AndroidApkAssertions.kt
+++ b/functional-test-utils/src/main/kotlin/apk/AndroidApkAssertions.kt
@@ -36,7 +36,7 @@ public fun Assert<ApkInspector>.hasGeneratedAotFiles(
     moduleBaseName: String,
 ): Unit = all {
     val packageFqn = targetPackage.replace(".", "/")
-    hasGeneratedModuleClassBytecode("$packageFqn/${moduleBaseName}Module")
+    hasGeneratedModuleClassBytecode("$packageFqn/$moduleBaseName")
     hasGeneratedMachineClassBytecode("$packageFqn/${moduleBaseName}Machine")
     hasGeneratedResource(targetPackage, "$moduleBaseName.meta")
 }

--- a/functional-test-utils/src/main/kotlin/testmatrix/TestMatrix.kt
+++ b/functional-test-utils/src/main/kotlin/testmatrix/TestMatrix.kt
@@ -100,7 +100,7 @@ public class TestMatrix {
         return sequence {
             gradleCompatibleVersions.forEach { gradleVersion ->
                 agpCompatibleVersions.forEach { agpVersion ->
-                    kotlinVersions.forEach { kotlinVersion ->
+                    kotlinVersions().forEach { kotlinVersion ->
                         yield(Triple(gradleVersion, agpVersion, kotlinVersion))
                     }
                 }
@@ -112,22 +112,20 @@ public class TestMatrix {
     }
 
     // Allow setting a single, fixed Gradle version via environment variables
-    private fun gradleVersions(): List<Version> {
-        val gradleVersion = System.getenv("TEST_GRADLE_VERSION")
-        return if (gradleVersion == null) {
-            gradleVersions
-        } else {
-            listOf(Version.parse(gradleVersion))
-        }
-    }
+    private fun gradleVersions(): List<Version> = systemEnvVersions("TEST_GRADLE_VERSION", gradleVersions)
 
     // Allow setting a single, fixed AGP version via environment variables
-    private fun agpVersions(): List<Version> {
-        val agpVersion = System.getenv("TEST_AGP_VERSION")
-        return if (agpVersion == null) {
-            agpVersions
+    private fun agpVersions(): List<Version> = systemEnvVersions("TEST_AGP_VERSION", agpVersions)
+
+    // Allow setting a single, fixed Kotlin version via environment variables
+    private fun kotlinVersions(): List<Version> = systemEnvVersions("TEST_KOTLIN_VERSION", kotlinVersions)
+
+    private fun systemEnvVersions(envName: String, orElse: List<Version>): List<Version> {
+        val version = System.getenv(envName)
+        return if (version == null) {
+            orElse
         } else {
-            listOf(Version.parse(agpVersion))
+            listOf(Version.parse(version))
         }
     }
 }

--- a/functional-test-utils/src/main/kotlin/testmatrix/compatibility/AgpVersionCompatibility.kt
+++ b/functional-test-utils/src/main/kotlin/testmatrix/compatibility/AgpVersionCompatibility.kt
@@ -12,6 +12,7 @@ import at.released.wasm2class.test.functional.testmatrix.compatibility.GradleVer
 import at.released.wasm2class.test.functional.testmatrix.compatibility.GradleVersionCompatibility.GRADLE_8_0
 import at.released.wasm2class.test.functional.testmatrix.compatibility.GradleVersionCompatibility.GRADLE_8_10_2
 import at.released.wasm2class.test.functional.testmatrix.compatibility.GradleVersionCompatibility.GRADLE_8_11_1
+import at.released.wasm2class.test.functional.testmatrix.compatibility.GradleVersionCompatibility.GRADLE_8_13
 import at.released.wasm2class.test.functional.testmatrix.compatibility.GradleVersionCompatibility.GRADLE_8_2
 import at.released.wasm2class.test.functional.testmatrix.compatibility.GradleVersionCompatibility.GRADLE_8_4
 import at.released.wasm2class.test.functional.testmatrix.compatibility.GradleVersionCompatibility.GRADLE_8_6
@@ -61,6 +62,7 @@ internal object AgpVersionCompatibility {
         agpVersion: Version,
         gradleVersion: Version,
     ) = when {
+        agpVersion >= AGP_8_11_0_RC01 -> gradleVersion >= GRADLE_8_13
         agpVersion >= AGP_8_9_0 -> gradleVersion >= GRADLE_8_11_1
         agpVersion >= AGP_8_8_0 -> gradleVersion >= GRADLE_8_10_2
         agpVersion >= AGP_8_7_0 -> gradleVersion >= GRADLE_8_9

--- a/functional-test-utils/src/main/kotlin/testmatrix/compatibility/KotlinVersionCompatibility.kt
+++ b/functional-test-utils/src/main/kotlin/testmatrix/compatibility/KotlinVersionCompatibility.kt
@@ -10,7 +10,7 @@ package at.released.wasm2class.test.functional.testmatrix.compatibility
 import at.released.wasm2class.test.functional.testmatrix.Version
 import at.released.wasm2class.test.functional.testmatrix.compatibility.AgpVersionCompatibility.AGP_7_4_0
 import at.released.wasm2class.test.functional.testmatrix.compatibility.AgpVersionCompatibility.AGP_8_1_1
-import at.released.wasm2class.test.functional.testmatrix.compatibility.AgpVersionCompatibility.AGP_8_5_0
+import at.released.wasm2class.test.functional.testmatrix.compatibility.AgpVersionCompatibility.AGP_8_5_2
 import at.released.wasm2class.test.functional.testmatrix.compatibility.GradleVersionCompatibility.GRADLE_6_8_3
 import at.released.wasm2class.test.functional.testmatrix.compatibility.GradleVersionCompatibility.GRADLE_7_6_5
 import at.released.wasm2class.test.functional.testmatrix.compatibility.GradleVersionCompatibility.GRADLE_8_1_1
@@ -33,7 +33,7 @@ internal object KotlinVersionCompatibility {
         gradle: Version,
     ): Boolean = when {
         kotlin >= KOTLIN_2_1_0 -> gradle > GRADLE_7_6_5 && agp > Version(7, 3, 1)
-        kotlin >= KOTLIN_2_0_20 -> gradle > GRADLE_6_8_3 && agp in Version(7, 1, 3)..AGP_8_5_0
+        kotlin >= KOTLIN_2_0_20 -> gradle > GRADLE_6_8_3 && agp in Version(7, 1, 3)..AGP_8_5_2
         kotlin >= KOTLIN_2_0_0 -> gradle in GRADLE_6_8_3..GRADLE_8_5 && agp in Version(7, 1, 3)..Version(8, 3, 1)
         kotlin >= KOTLIN_1_9_20 -> gradle in GRADLE_6_8_3..GRADLE_8_1_1 && agp in Version(4, 2, 2)..AGP_8_1_1
         kotlin >= KOTLIN_1_9_0 -> gradle in GRADLE_6_8_3..GRADLE_7_6_5 && agp in Version(4, 2, 2)..AGP_7_4_0

--- a/functional-test-utils/src/main/kotlin/testproject/VersionCatalogTomlGenerator.kt
+++ b/functional-test-utils/src/main/kotlin/testproject/VersionCatalogTomlGenerator.kt
@@ -21,6 +21,7 @@ public fun VersionCatalog.toLibsVersionsToml(): FileContent {
 
         [libraries]
         chicory-wasi = { module = "com.dylibso.chicory:wasi", version.ref = "chicory" }
+        chicory-annotations = { module = "com.dylibso.chicory:annotations", version.ref = "chicory" }
 
         [plugins]
         android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ kotlin = "2.1.21"
 android-tools = "31.10.1"
 android-tools-dexlib2 = "3.0.9"
 assertk = "0.28.1"
-chicory = "1.2.1"
+chicory = "1.4.0"
 detekt = "1.23.8"
 gradle-plugin-publish = "1.3.1"
 gradle-maven-publish-plugin = "0.31.0"
@@ -25,7 +25,7 @@ android-tools-apkparser-binary-resources = { group = "com.android.tools.apkparse
 android-tools-smali-dexlib2 = { group = "com.android.tools.smali", name = "smali-dexlib2", version.ref = "android-tools-dexlib2" }
 assertk = { group = "com.willowtreeapps.assertk", name = "assertk", version.ref = "assertk" }
 chicory-runtime = { module = "com.dylibso.chicory:runtime", version.ref = "chicory" }
-chicory-aot-build = { module = "com.dylibso.chicory:aot-build-time-experimental", version.ref = "chicory" }
+chicory-build-time-compiler = { module = "com.dylibso.chicory:build-time-compiler", version.ref = "chicory" }
 chicory-wasm = { module = "com.dylibso.chicory:wasm", version.ref = "chicory" }
 junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit5" }
 junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api" }

--- a/gradle/verification-keyring.keys
+++ b/gradle/verification-keyring.keys
@@ -2936,6 +2936,21 @@ On/eScLdx27sje7q3sBENw==
 =TzHJ
 -----END PGP PUBLIC KEY BLOCK-----
 
+pub    7D71833C1A8AF208
+uid    Chicory Team <oss@dylibso.com>
+
+sub    F0F86573147C1583
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mDMEaBDwZBYJKwYBBAHaRw8BAQdAdzp1o0Y1oGdzO0BBCrRliq6YyNB0u0tZ1d3g
++98M7Ke0HkNoaWNvcnkgVGVhbSA8b3NzQGR5bGlic28uY29tPrg4BGgQ8GQSCisG
+AQQBl1UBBQEBB0DzUm/SnIRBkJ+nUIoGykHfJPtngavHqJLXUO0RBhF7NAMBCAeI
+fgQYFgoAJhYhBA/LvYITYqnDkjkWLn1xgzwaivIIBQJoEPBkAhsMBQkFo5qAAAoJ
+EH1xgzwaivIImu8BAL5X8+YkUX9u/6vQ8Q5aZphx5SMrscZCs4GoXadac3o3AP0d
+7i/OEbAZO/n0llxPqHn2CyfQqMRNtD81UTUIxCDaDQ==
+=3Qvg
+-----END PGP PUBLIC KEY BLOCK-----
+
 pub    7EB97D110DFADD60
 uid    Niall Gallagher (www.npgall.com) <niall@npgall.com>
 

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -26,6 +26,7 @@
          <trusted-key id="0785B3EFF60B1B1BEA94E0BB7C25280EAE63EBE5" group="org.apache.httpcomponents"/>
          <trusted-key id="09939C73246B4BA7444CAA453D002DBC5EA9615F" group="dev.drewhamilton.poko" name="poko-annotations-jvm"/>
          <trusted-key id="0F06FF86BEEAF4E71866EE5232EE5355A6BC6E42" group="^com[.]android[.]tools($|([.].*))" regex="true"/>
+         <trusted-key id="0FCBBD821362A9C39239162E7D71833C1A8AF208" group="com.dylibso.chicory"/>
          <trusted-key id="19BEAB2D799C020F17C69126B16698A4ADF4D638" group="org.checkerframework" name="checker-qual"/>
          <trusted-key id="1BD97A6A154E7810EE0BC832E2F38302C8075E3D">
             <trusting group="com.gradle.publish" name="plugin-publish-plugin"/>

--- a/plugin/api/plugin.api
+++ b/plugin/api/plugin.api
@@ -1,3 +1,11 @@
+public final class at/released/wasm2class/InterpreterFallback : java/lang/Enum {
+	public static final field FAIL Lat/released/wasm2class/InterpreterFallback;
+	public static final field SILENT Lat/released/wasm2class/InterpreterFallback;
+	public static final field WARN Lat/released/wasm2class/InterpreterFallback;
+	public static fun valueOf (Ljava/lang/String;)Lat/released/wasm2class/InterpreterFallback;
+	public static fun values ()[Lat/released/wasm2class/InterpreterFallback;
+}
+
 public final class at/released/wasm2class/Wasm2ClassBasePlugin : org/gradle/api/Plugin {
 	public fun <init> ()V
 	public synthetic fun apply (Ljava/lang/Object;)V
@@ -19,6 +27,8 @@ public abstract interface annotation class at/released/wasm2class/Wasm2ClassGene
 
 public class at/released/wasm2class/Wasm2ClassMachineModuleSpec : org/gradle/api/Named {
 	public fun <init> (Ljava/lang/String;Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun getInterpretedFunctions ()Lorg/gradle/api/provider/SetProperty;
+	public final fun getInterpreterFallback ()Lorg/gradle/api/provider/Property;
 	public fun getName ()Ljava/lang/String;
 	public final fun getOutputClassPrefix ()Lorg/gradle/api/provider/Property;
 	public final fun getTargetPackage ()Lorg/gradle/api/provider/Property;

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -45,7 +45,7 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 dependencies {
-    compileOnly(libs.chicory.aot.build)
+    compileOnly(libs.chicory.build.time.compiler)
     compileOnly(libs.chicory.runtime)
     compileOnly(libs.chicory.wasm)
     compileOnly(libs.agp.plugin.api)

--- a/plugin/src/main/kotlin/AndroidPluginIntegration.kt
+++ b/plugin/src/main/kotlin/AndroidPluginIntegration.kt
@@ -40,7 +40,7 @@ internal fun Project.setupAndroidPluginIntegration() {
 
     // Configure global Wasm2ClassExtension with android-specific defaults
     val wasm2ClassExtension = extensions.getByType(Wasm2ClassExtension::class.java).apply {
-        outputDirectory.convention(layout.buildDirectory.dir("generated-chicory-aot/android"))
+        outputDirectory.convention(layout.buildDirectory.dir("generated-chicory/android"))
         targetPackage.convention(extensions.getByType(CommonExtension::class.java).namespace)
     }
 
@@ -71,25 +71,25 @@ internal fun Project.setupAndroidPluginIntegration() {
 
         // To add generated .class files to the compile classpath, we first need to package them into a JAR archive.
         // There might be a simpler way to do this.
-        val packAotMachineClassesJar: TaskProvider<Jar> = tasks.register(
-            "${variant.name}PackAotMachineJar",
+        val packMachineClassesJar: TaskProvider<Jar> = tasks.register(
+            "${variant.name}PackWasmMachineJar",
             Jar::class.java,
         ) {
             from(wasm2ClassTask.flatMap(Wasm2ClassTask::outputClasses))
             destinationDirectory.set(
-                wasm2ClassExtension.outputDirectory.map { it.dir("${variant.name}AotMachineClassesJar") },
+                wasm2ClassExtension.outputDirectory.map { it.dir("${variant.name}WasmMachineClassesJar") },
             )
-            archiveFileName.set("${variant.name}-aot-machine-classes.jar")
+            archiveFileName.set("${variant.name}-wasm-machine-classes.jar")
         }
 
-        val aotMachineJar = "${variant.name}AotMachineJar"
-        val aotMachineJarConfiguration = configurations.create(aotMachineJar) {
+        val wasmMachineJar = "${variant.name}WasmMachineJar"
+        val wasmMachineJarConfiguration = configurations.create(wasmMachineJar) {
             isCanBeConsumed = false
             isCanBeResolved = false
             isVisible = false
         }
-        dependencies.add(aotMachineJar, files(packAotMachineClassesJar.flatMap(Jar::getArchiveFile)))
-        variant.compileConfiguration.extendsFrom(aotMachineJarConfiguration)
+        dependencies.add(wasmMachineJar, files(packMachineClassesJar.flatMap(Jar::getArchiveFile)))
+        variant.compileConfiguration.extendsFrom(wasmMachineJarConfiguration)
     }
 
     project.dependencies.add("implementation", Deps.CHICORY_RUNTIME)

--- a/plugin/src/main/kotlin/InterpreterFallback.kt
+++ b/plugin/src/main/kotlin/InterpreterFallback.kt
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Alexey Illarionov and the wasm2class-gradle-plugin project contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package at.released.wasm2class
+
+/**
+ * Enum representing the fallback behavior for when the compiler needs to fallback to using
+ * the interpreter.
+ */
+public enum class InterpreterFallback {
+    /**
+     * The compiler will silently use the interpreter as a fallback without any notification.
+     */
+    SILENT,
+
+    /**
+     * The compiler will log a warning message to stderr when it falls back to using the interpreter.
+     */
+    WARN,
+
+    /**
+     * The compiler will throw an exception if it needs to fall back to using the interpreter.
+     */
+    FAIL,
+}

--- a/plugin/src/main/kotlin/JavaPluginIntegration.kt
+++ b/plugin/src/main/kotlin/JavaPluginIntegration.kt
@@ -12,7 +12,7 @@ import org.gradle.api.plugins.JavaPluginExtension
 
 internal fun Project.setupJavaPluginIntegration() {
     val wasm2ClassExtension: Wasm2ClassExtension = extensions.getByType(Wasm2ClassExtension::class.java)
-    wasm2ClassExtension.outputDirectory.convention(layout.buildDirectory.dir("generated-chicory-aot/java"))
+    wasm2ClassExtension.outputDirectory.convention(layout.buildDirectory.dir("generated-chicory/java"))
 
     val wasm2classTask = registerWasm2ClassTask()
 

--- a/plugin/src/main/kotlin/Wasm2ClassBasePlugin.kt
+++ b/plugin/src/main/kotlin/Wasm2ClassBasePlugin.kt
@@ -5,7 +5,7 @@
 
 package at.released.wasm2class
 
-import at.released.wasm2class.Wasm2ClassConstants.Configurations.CHICORY_AOT_COMPILER
+import at.released.wasm2class.Wasm2ClassConstants.Configurations.CHICORY_COMPILER
 import at.released.wasm2class.Wasm2ClassConstants.Deps
 import at.released.wasm2class.Wasm2ClassConstants.WASM2CLASS_EXTENSION_NAME
 import org.gradle.api.Plugin
@@ -17,20 +17,20 @@ public class Wasm2ClassBasePlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.extensions.create(WASM2CLASS_EXTENSION_NAME, Wasm2ClassExtension::class.java)
 
-        val chicoryAotDependencies = target.configurations.create(CHICORY_AOT_COMPILER) {
+        val chicoryBuildTimeDependencies = target.configurations.create(CHICORY_COMPILER) {
             isCanBeResolved = false
             isCanBeConsumed = false
             isVisible = false
-            description = "The classpath for the Chicory AOT precompiler class generator"
+            description = "The classpath for the Chicory build time compiler"
             defaultDependencies {
-                add(target.dependencies.create(Deps.CHICORY_AOT_BUILD))
+                add(target.dependencies.create(Deps.CHICORY_BUILD_TIME_COMPILER))
             }
         }
 
-        target.configurations.create(Wasm2ClassConstants.Configurations.CHICORY_AOT_COMPILER_RUNTIME_CLASSPATH) {
+        target.configurations.create(Wasm2ClassConstants.Configurations.CHICORY_COMPILER_RUNTIME_CLASSPATH) {
             isCanBeResolved = true
             isCanBeConsumed = false
-            extendsFrom(chicoryAotDependencies)
+            extendsFrom(chicoryBuildTimeDependencies)
             attributes {
                 attribute(Usage.USAGE_ATTRIBUTE, target.objects.named(Usage.JAVA_RUNTIME))
             }

--- a/plugin/src/main/kotlin/Wasm2ClassConstants.kt
+++ b/plugin/src/main/kotlin/Wasm2ClassConstants.kt
@@ -9,14 +9,14 @@ internal object Wasm2ClassConstants {
     internal const val WASM2CLASS_EXTENSION_NAME = "wasm2class"
 
     object Deps {
-        const val CHICORY_VERSION = "1.2.1"
+        const val CHICORY_VERSION = "1.4.0"
         const val CHICORY_GROUP = "com.dylibso.chicory"
-        const val CHICORY_AOT_BUILD = "$CHICORY_GROUP:aot-build-time-experimental:$CHICORY_VERSION"
+        const val CHICORY_BUILD_TIME_COMPILER = "$CHICORY_GROUP:build-time-compiler:$CHICORY_VERSION"
         const val CHICORY_RUNTIME = "$CHICORY_GROUP:runtime:$CHICORY_VERSION"
     }
 
     object Configurations {
-        internal const val CHICORY_AOT_COMPILER = "chicoryAotCompiler"
-        internal const val CHICORY_AOT_COMPILER_RUNTIME_CLASSPATH = "chicoryAotCompilerRuntimeClasspath"
+        internal const val CHICORY_COMPILER = "chicoryCompiler"
+        internal const val CHICORY_COMPILER_RUNTIME_CLASSPATH = "chicoryCompilerRuntimeClasspath"
     }
 }

--- a/plugin/src/main/kotlin/Wasm2ClassExtension.kt
+++ b/plugin/src/main/kotlin/Wasm2ClassExtension.kt
@@ -38,7 +38,7 @@ public abstract class Wasm2ClassExtension @Inject constructor(
      * The root directory for the generated classes.
      */
     public val outputDirectory: DirectoryProperty = objects.directoryProperty().convention(
-        layout.buildDirectory.dir("generated-chicory-aot"),
+        layout.buildDirectory.dir("generated-chicory"),
     )
 
     /**

--- a/plugin/src/main/kotlin/Wasm2ClassMachineModuleSpec.kt
+++ b/plugin/src/main/kotlin/Wasm2ClassMachineModuleSpec.kt
@@ -9,12 +9,14 @@ import org.gradle.api.Named
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity.NONE
 import org.gradle.kotlin.dsl.property
+import org.gradle.kotlin.dsl.setProperty
 import javax.inject.Inject
 
 @Wasm2ClassGeneratorDsl
@@ -40,9 +42,7 @@ public open class Wasm2ClassMachineModuleSpec @Inject constructor(
     public val targetPackage: Property<String> = objects.property<String>()
 
     /**
-     * The base name for generated classes in the format of `<target package>.<base name>`.
-     * For example: *"com.example.Add"*. A class named *"com.example.AddModule"*
-     * will be generated based on this name.
+     * Fully qualified name for the generated class
      *
      * Default: "[targetPackage].[name.capitalized()][name]"
      */
@@ -50,6 +50,20 @@ public open class Wasm2ClassMachineModuleSpec @Inject constructor(
     public val outputClassPrefix: Property<String> = objects.property<String>().convention(
         targetPackage.map { "$it.${getName().capitalizeAscii()}" },
     )
+
+    /**
+     * The interpreter fallback to be used
+     */
+    @get:Input
+    public val interpreterFallback: Property<InterpreterFallback> = objects.property<InterpreterFallback>().convention(
+        InterpreterFallback.FAIL,
+    )
+
+    /**
+     * The set of interpreted functions
+     */
+    @get:Input
+    public val interpretedFunctions: SetProperty<Int> = objects.setProperty<Int>().convention(emptySet())
 
     @Input
     override fun getName(): String = name

--- a/plugin/testFixtures/projects/android-java-app/build.gradle.kts
+++ b/plugin/testFixtures/projects/android-java-app/build.gradle.kts
@@ -48,5 +48,6 @@ wasm2class {
 }
 
 dependencies {
+    implementation(libs.chicory.annotations)
     implementation(libs.chicory.wasi)
 }

--- a/plugin/testFixtures/projects/android-java-app/proguard-rules.pro
+++ b/plugin/testFixtures/projects/android-java-app/proguard-rules.pro
@@ -3,15 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 -repackageclasses
--dontobfuscate
 
--dontwarn com.dylibso.chicory.experimental.hostmodule.annotations.Buffer
--dontwarn com.dylibso.chicory.experimental.hostmodule.annotations.HostModule
--dontwarn com.dylibso.chicory.experimental.hostmodule.annotations.WasmExport
 -dontwarn com.google.errorprone.annotations.FormatMethod
 -dontwarn java.lang.System$Logger$Level
 -dontwarn java.lang.System$Logger
 
--keepclasseswithmembers,allowoptimization public final class **Module {
-    public static com.dylibso.chicory.wasm.WasmModule load();
-}
+-if public final class ** { public static com.dylibso.chicory.wasm.WasmModule load(); }
+-keepnames class <1>

--- a/plugin/testFixtures/projects/android-java-app/src/main/java/com/example/wasm2class/android/java/app/MainActivity.java
+++ b/plugin/testFixtures/projects/android-java-app/src/main/java/com/example/wasm2class/android/java/app/MainActivity.java
@@ -41,8 +41,8 @@ public class MainActivity extends Activity {
 
     private static void runHelloWorld(WasiPreview1 wasi) {
         var store = new Store().addFunction(wasi.toHostFunctions());
-        var clockInstance = store.instantiate("helloworld", importValues -> Instance.builder(HelloworldModule.load())
-                .withMachineFactory(HelloworldModule::create)
+        var clockInstance = store.instantiate("helloworld", importValues -> Instance.builder(Helloworld.load())
+                .withMachineFactory(Helloworld::create)
                 .withImportValues(importValues)
                 .withStart(false)
                 .build()
@@ -52,8 +52,8 @@ public class MainActivity extends Activity {
 
     private static void runClock(WasiPreview1 wasi) {
         var store = new Store().addFunction(wasi.toHostFunctions());
-        var clockInstance = store.instantiate("clock", importValues -> Instance.builder(ClockModule.load())
-                .withMachineFactory(ClockModule::create)
+        var clockInstance = store.instantiate("clock", importValues -> Instance.builder(Clock.load())
+                .withMachineFactory(Clock::create)
                 .withImportValues(importValues)
                 .withStart(false)
                 .build()

--- a/plugin/testFixtures/projects/android-kotlin-lib-flavors/android-app/proguard-rules.pro
+++ b/plugin/testFixtures/projects/android-kotlin-lib-flavors/android-app/proguard-rules.pro
@@ -2,4 +2,5 @@
 # SPDX-FileCopyrightText: 2025 Alexey Illarionov and the wasm2class-gradle-plugin project contributors
 # SPDX-License-Identifier: Apache-2.0
 #
+-allowaccessmodification
 -repackageclasses

--- a/plugin/testFixtures/projects/android-kotlin-lib-flavors/android-lib1/build.gradle.kts
+++ b/plugin/testFixtures/projects/android-kotlin-lib-flavors/android-lib1/build.gradle.kts
@@ -76,5 +76,6 @@ wasm2class {
 }
 
 dependencies {
+    implementation(libs.chicory.annotations)
     implementation(libs.chicory.wasi)
 }

--- a/plugin/testFixtures/projects/android-kotlin-lib-flavors/android-lib1/consumer-rules.pro
+++ b/plugin/testFixtures/projects/android-kotlin-lib-flavors/android-lib1/consumer-rules.pro
@@ -3,13 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
--dontwarn com.dylibso.chicory.experimental.hostmodule.annotations.Buffer
--dontwarn com.dylibso.chicory.experimental.hostmodule.annotations.HostModule
--dontwarn com.dylibso.chicory.experimental.hostmodule.annotations.WasmExport
 -dontwarn com.google.errorprone.annotations.FormatMethod
 -dontwarn java.lang.System$Logger$Level
 -dontwarn java.lang.System$Logger
 
--keepclasseswithmembers,allowoptimization public final class **Module {
-    public static com.dylibso.chicory.wasm.WasmModule load();
-}
+-if public final class ** { public static com.dylibso.chicory.wasm.WasmModule load(); }
+-keepnames class <1>

--- a/plugin/testFixtures/projects/android-kotlin-lib-flavors/android-lib1/proguard-rules.pro
+++ b/plugin/testFixtures/projects/android-kotlin-lib-flavors/android-lib1/proguard-rules.pro
@@ -12,6 +12,6 @@
     public protected *;
 }
 
--keepclasseswithmembers,allowoptimization public final class **Module {
+-keepclasseswithmembers,allowoptimization public final class * {
     public static com.dylibso.chicory.wasm.WasmModule load();
 }

--- a/plugin/testFixtures/projects/android-kotlin-lib-flavors/android-lib1/src/fullStaging/kotlin/StagingClockLib.kt
+++ b/plugin/testFixtures/projects/android-kotlin-lib-flavors/android-lib1/src/fullStaging/kotlin/StagingClockLib.kt
@@ -8,7 +8,7 @@ package com.example.wasm2class.android.kotlin.lib.lib1
 import com.dylibso.chicory.runtime.ImportValues
 import com.dylibso.chicory.runtime.Instance
 import com.dylibso.chicory.runtime.Store
-import com.example.wasm2class.android.kotlin.lib.lib1.clock.ClockModule
+import com.example.wasm2class.android.kotlin.lib.lib1.clock.Clock
 
 public object StagingClockLib {
     fun runClock() {
@@ -16,8 +16,8 @@ public object StagingClockLib {
             @Suppress("SpreadOperator")
             val store = Store().addFunction(*wasi.toHostFunctions())
             val clockInstance = store.instantiate("clock") { importValues: ImportValues? ->
-                Instance.builder(ClockModule.load())
-                    .withMachineFactory(ClockModule::create)
+                Instance.builder(Clock.load())
+                    .withMachineFactory(Clock::create)
                     .withImportValues(importValues)
                     .withStart(false)
                     .build()

--- a/plugin/testFixtures/projects/android-kotlin-lib-flavors/android-lib1/src/main/kotlin/HelloworldLib.kt
+++ b/plugin/testFixtures/projects/android-kotlin-lib-flavors/android-lib1/src/main/kotlin/HelloworldLib.kt
@@ -14,8 +14,8 @@ public object HelloworldLib {
             @Suppress("SpreadOperator")
             val store = Store().addFunction(*wasi.toHostFunctions())
             val clockInstance = store.instantiate("helloworld") { importValues ->
-                Instance.builder(HelloworldModule.load())
-                    .withMachineFactory(HelloworldModule::create)
+                Instance.builder(Helloworld.load())
+                    .withMachineFactory(Helloworld::create)
                     .withImportValues(importValues)
                     .withStart(false)
                     .build()

--- a/plugin/testFixtures/projects/java-app/build.gradle.kts
+++ b/plugin/testFixtures/projects/java-app/build.gradle.kts
@@ -17,10 +17,15 @@ wasm2class {
         create("clock") {
             wasm = file("../testwasm/clock.wasm")
         }
+        create("helloworldInterpreted") {
+            wasm = file("../testwasm/helloworld.wasm")
+            interpretedFunctions = setOf(4, 5, 6, 7, 8)
+        }
     }
 }
 
 dependencies {
+    implementation(libs.chicory.annotations)
     implementation(libs.chicory.wasi)
 }
 

--- a/plugin/testFixtures/projects/java-app/src/main/java/com/example/wasm2class/java/app/Main.java
+++ b/plugin/testFixtures/projects/java-app/src/main/java/com/example/wasm2class/java/app/Main.java
@@ -18,13 +18,25 @@ public class Main {
         try (var wasi = WasiPreview1.builder().withOptions(wasiOptions).build()) {
             runHelloWorld(wasi);
             runClock(wasi);
+            runHelloWorldInterpreted(wasi);
         }
     }
 
     private static void runHelloWorld(WasiPreview1 wasi) {
         var store = new Store().addFunction(wasi.toHostFunctions());
-        var clockInstance = store.instantiate("helloworld", importValues -> Instance.builder(HelloworldModule.load())
-                .withMachineFactory(HelloworldModule::create)
+        var instance = store.instantiate("helloworld", importValues -> Instance.builder(Helloworld.load())
+                .withMachineFactory(Helloworld::create)
+                .withImportValues(importValues)
+                .withStart(false)
+                .build()
+        );
+        executeWasiStart(instance);
+    }
+
+    private static void runClock(WasiPreview1 wasi) {
+        var store = new Store().addFunction(wasi.toHostFunctions());
+        var clockInstance = store.instantiate("clock", importValues -> Instance.builder(Clock.load())
+                .withMachineFactory(Clock::create)
                 .withImportValues(importValues)
                 .withStart(false)
                 .build()
@@ -32,15 +44,16 @@ public class Main {
         executeWasiStart(clockInstance);
     }
 
-    private static void runClock(WasiPreview1 wasi) {
+    private static void runHelloWorldInterpreted(WasiPreview1 wasi) {
         var store = new Store().addFunction(wasi.toHostFunctions());
-        var clockInstance = store.instantiate("clock", importValues -> Instance.builder(ClockModule.load())
-                .withMachineFactory(ClockModule::create)
-                .withImportValues(importValues)
-                .withStart(false)
-                .build()
+        var instance = store.instantiate("helloworldInterpreted", importValues ->
+                Instance.builder(HelloworldInterpreted.load())
+                        .withMachineFactory(HelloworldInterpreted::create)
+                        .withImportValues(importValues)
+                        .withStart(false)
+                        .build()
         );
-        executeWasiStart(clockInstance);
+        executeWasiStart(instance);
     }
 
     private static void executeWasiStart(Instance instance) {

--- a/plugin/testFixtures/projects/java-lib/javalib-lib/build.gradle.kts
+++ b/plugin/testFixtures/projects/java-lib/javalib-lib/build.gradle.kts
@@ -21,5 +21,6 @@ wasm2class {
 }
 
 dependencies {
+    implementation(libs.chicory.annotations)
     implementation(libs.chicory.wasi)
 }

--- a/plugin/testFixtures/projects/java-lib/javalib-lib/src/main/java/com/example/wasm2class/javalib/lib/Lib.java
+++ b/plugin/testFixtures/projects/java-lib/javalib-lib/src/main/java/com/example/wasm2class/javalib/lib/Lib.java
@@ -19,8 +19,8 @@ public class Lib {
     public static void runHelloWorld() {
         try (var wasi = WasiPreview1.builder().withOptions(wasiOptions).build()) {
             var store = new Store().addFunction(wasi.toHostFunctions());
-            var clockInstance = store.instantiate("helloworld", importValues -> Instance.builder(HelloworldModule.load())
-                    .withMachineFactory(HelloworldModule::create)
+            var clockInstance = store.instantiate("helloworld", importValues -> Instance.builder(Helloworld.load())
+                    .withMachineFactory(Helloworld::create)
                     .withImportValues(importValues)
                     .withStart(false)
                     .build()
@@ -32,8 +32,8 @@ public class Lib {
     public static void runClock() {
         try (var wasi = WasiPreview1.builder().withOptions(wasiOptions).build()) {
             var store = new Store().addFunction(wasi.toHostFunctions());
-            var clockInstance = store.instantiate("clock", importValues -> Instance.builder(ClockModule.load())
-                    .withMachineFactory(ClockModule::create)
+            var clockInstance = store.instantiate("clock", importValues -> Instance.builder(Clock.load())
+                    .withMachineFactory(Clock::create)
                     .withImportValues(importValues)
                     .withStart(false)
                     .build()

--- a/plugin/testFixtures/projects/kmp-jvm-android-app/build.gradle.kts
+++ b/plugin/testFixtures/projects/kmp-jvm-android-app/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
+            implementation(libs.chicory.annotations)
             implementation(libs.chicory.wasi)
         }
     }

--- a/plugin/testFixtures/projects/kmp-jvm-android-app/src/androidMain/kotlin/MainActivity.kt
+++ b/plugin/testFixtures/projects/kmp-jvm-android-app/src/androidMain/kotlin/MainActivity.kt
@@ -29,8 +29,8 @@ class MainActivity : Activity() {
             @Suppress("SpreadOperator")
             val store = Store().addFunction(*wasi.toHostFunctions())
             val clockInstance = store.instantiate("helloworld") { importValues ->
-                Instance.builder(HelloworldModule.load())
-                    .withMachineFactory(HelloworldModule::create)
+                Instance.builder(Helloworld.load())
+                    .withMachineFactory(Helloworld::create)
                     .withImportValues(importValues)
                     .withStart(false)
                     .build()
@@ -42,8 +42,8 @@ class MainActivity : Activity() {
             @Suppress("SpreadOperator")
             val store = Store().addFunction(*wasi.toHostFunctions())
             val clockInstance = store.instantiate("clock") { importValues ->
-                Instance.builder(ClockModule.load())
-                    .withMachineFactory(ClockModule::create)
+                Instance.builder(Clock.load())
+                    .withMachineFactory(Clock::create)
                     .withImportValues(importValues)
                     .withStart(false)
                     .build()

--- a/plugin/testFixtures/projects/kmp-jvm-android-app/src/jvmMain/kotlin/Main.kt
+++ b/plugin/testFixtures/projects/kmp-jvm-android-app/src/jvmMain/kotlin/Main.kt
@@ -24,8 +24,8 @@ private fun runHelloWorld(wasi: WasiPreview1) {
     @Suppress("SpreadOperator")
     val store = Store().addFunction(*wasi.toHostFunctions())
     val clockInstance = store.instantiate("helloworld") { importValues ->
-        Instance.builder(HelloworldModule.load())
-            .withMachineFactory(HelloworldModule::create)
+        Instance.builder(Helloworld.load())
+            .withMachineFactory(Helloworld::create)
             .withImportValues(importValues)
             .withStart(false)
             .build()
@@ -37,8 +37,8 @@ private fun runClock(wasi: WasiPreview1) {
     @Suppress("SpreadOperator")
     val store = Store().addFunction(*wasi.toHostFunctions())
     val clockInstance = store.instantiate("clock") { importValues ->
-        Instance.builder(ClockModule.load())
-            .withMachineFactory(ClockModule::create)
+        Instance.builder(Clock.load())
+            .withMachineFactory(Clock::create)
             .withImportValues(importValues)
             .withStart(false)
             .build()

--- a/plugin/testFixtures/projects/kotlin-app/build.gradle.kts
+++ b/plugin/testFixtures/projects/kotlin-app/build.gradle.kts
@@ -39,5 +39,6 @@ wasm2class {
 }
 
 dependencies {
+    implementation(libs.chicory.annotations)
     implementation(libs.chicory.wasi)
 }

--- a/plugin/testFixtures/projects/kotlin-app/src/main/kotlin/Main.kt
+++ b/plugin/testFixtures/projects/kotlin-app/src/main/kotlin/Main.kt
@@ -27,8 +27,8 @@ private fun runHelloWorld(wasi: WasiPreview1) {
     @Suppress("SpreadOperator")
     val store = Store().addFunction(*wasi.toHostFunctions())
     val instance = store.instantiate("helloworld") { importValues ->
-        Instance.builder(HelloworldModule.load())
-            .withMachineFactory(HelloworldModule::create)
+        Instance.builder(Helloworld.load())
+            .withMachineFactory(Helloworld::create)
             .withImportValues(importValues)
             .withStart(false)
             .build()
@@ -40,8 +40,8 @@ private fun runClock(wasi: WasiPreview1) {
     @Suppress("SpreadOperator")
     val store = Store().addFunction(*wasi.toHostFunctions())
     val clockInstance = store.instantiate("clock") { importValues ->
-        Instance.builder(ClockModule.load())
-            .withMachineFactory(ClockModule::create)
+        Instance.builder(Clock.load())
+            .withMachineFactory(Clock::create)
             .withImportValues(importValues)
             .withStart(false)
             .build()


### PR DESCRIPTION
This is a binary-incompatible change. Many task names, configurations, classes, and paths have been renamed.

* The name of the declared module now corresponds to the name of the generated class, i.e., the "Module" suffix is no longer added automatically.

Configuration names changed:
* `chicoryAotCompiler` -> `chicoryCompiler`
* `chicoryAotCompilerRuntimeClasspath` -> `chicoryCompilerRuntimeClasspath`

Task names changed:
* `<target>CompileAotModuleWithJavac` -> `<target>CompileWasmModuleWithJavac`

The main build directory changed from <build>/generated-chicory-aot to `<build>/generated-chicory`

Added the ability to specify a list of function numbers to be executed using the interpreter.

Also check https://chicory.dev/blog/chicory-1.4.0